### PR TITLE
Build erlang 25.3.2.7 and 26.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
           - "ubuntu:focal"
           - "ubuntu:bionic"
         erlang_version:
+          - "26.1.2"
           - "26.0"
+          - "25.3.2.7"
           - "25.3"
           - "25.2.3"
           - "25.2.2"
@@ -82,6 +84,8 @@ jobs:
           - "18.0"
         exclude:
           # compilation fails on bionic, let's skip it for now
+          - image: "ubuntu:bionic"
+            erlang_version: "26.1.2"
           - image: "ubuntu:bionic"
             erlang_version: "26.0"
     steps:


### PR DESCRIPTION
(current latest for these major versions)

- 26.1 fixed many things in the erlang shell that were buggy in 26.0