### PR TITLE
Build packages for Ubuntu 24.04 (Noble Numbat)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG erlang_version=24.0
 # Erlang before 24.2 didn't support libssl3, so statically compile 1.1.1 if no available from the OS
 RUN libssl_version=$(dpkg-query --showformat='${Version}' --show libssl-dev); \
     if (dpkg --compare-versions "$erlang_version" ge 20.0 && dpkg --compare-versions "$erlang_version" lt 24.2 && dpkg --compare-versions "$libssl_version" ge 3.0.0); then \
-        curl https://www.openssl.org/source/openssl-1.1.1t.tar.gz | tar zx --strip-components=1 && \
+        curl -L https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1w/openssl-1.1.1w.tar.gz | tar zx --strip-components=1 && \
         ./config no-shared && \
         make -j$(nproc) && make install_sw; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,7 @@ RUN fpm -s dir -t deb \
 #RUN lintian *erlang*.deb || true
 
 ARG TARGETPLATFORM
-FROM --platform=$TARGETPLATFORM ${image} as tester
+FROM --platform=$TARGETPLATFORM ${image} AS tester
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y curl
 ARG rabbitmq_version=3.7.10

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Excluded erlang packages:
 
 ## Versions
 
-Every [version of Erlang that is released on GitHub](https://github.com/erlang/otp/releases) is built, currently for Ubuntu 20.04 and 22.04.
+Every [version of Erlang that is released on GitHub](https://github.com/erlang/otp/releases) is built, currently for Ubuntu 20.04, 22.04 and 24.04.
 
 ## Install
 

--- a/bin/missing-versions
+++ b/bin/missing-versions
@@ -2,7 +2,7 @@
 require_relative "../lib/github"
 require_relative "../lib/packagecloud"
 
-DISTS = %w[ubuntu/jammy ubuntu/focal debian/bookworm debian/bullseye].freeze
+DISTS = %w[ubuntu/noble ubuntu/jammy ubuntu/focal debian/bookworm debian/bullseye].freeze
 PLATFORMS = %w[amd64 arm64].freeze
 # 24.2 supports OpenSSL 3 and modern gcc/autoconf versions
 FIRST_SANE_VERSION = Gem::Version.new("24.2")


### PR DESCRIPTION
See individual commits, biggest change is that we will use [`dpkg-shlibdeps(1)`](https://manpages.ubuntu.com/manpages/en/man1/dpkg-shlibdeps.1.html) to get the list of dependencies. It will change the behavior slightly, as we will now have versions constraints which I would argue is a slight improvement.

Example:

```
$ docker build --progress=plain --target tester --build-arg image=ubuntu:jammy --build-arg erlang_version=26.0 --build-arg rabbitmq_version=3.13.0 .

# now
=> Depends: procps, libc6 (>= 2.34), libgcc-s1 (>= 3.0), libstdc++6 (>= 11), libtinfo6 (>= 6), zlib1g (>= 1:1.2.8)

# before
=> Depends: procps, libc6,libgcc-s1,libstdc++6,libtinfo6,zlib1g
```