### PR TITLE
Fix "Matrix must define at least one vector"

### DIFF
--- a/.github/workflows/build-all-and-upload.yml
+++ b/.github/workflows/build-all-and-upload.yml
@@ -30,6 +30,7 @@ jobs:
 
   build-and-upload:
     needs: missing-versions
+    if: ${{ needs.missing-versions.outputs.matrix != '[]' }}
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 10


### PR DESCRIPTION
Skip running the job if `bin/missing-versions` yields an empty array.

Currently, we get a daily error (save for the days where there was an Erlang release), [example](https://github.com/cloudamqp/erlang-packages/actions/runs/10663720608).