### PR TITLE
Ensure action fails if `bin/missing-versions` fail

### DIFF
--- a/.github/workflows/build-all-and-upload.yml
+++ b/.github/workflows/build-all-and-upload.yml
@@ -21,7 +21,9 @@ jobs:
           ruby-version: ruby
       - name: Check missing versions
         id: missing-versions
-        run: echo "matrix=$(bin/missing-versions)" >> "$GITHUB_OUTPUT"
+        run: |
+          missing_versions=$(bin/missing-versions)
+          echo "matrix=$missing_versions" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}


### PR DESCRIPTION
Previously we'd "shadow" the `bin/missing-versions` exit code with the one from `echo`, split into two discrete steps to catch that.

See example at https://github.com/cloudamqp/erlang-packages/actions/runs/10880399934 where it's hard to understand what went wrong without looking closer.