### PR TITLE
Skip 'strange' Erlang GitHub release

### DIFF
--- a/bin/missing-versions
+++ b/bin/missing-versions
@@ -7,6 +7,14 @@ PLATFORMS = %w[amd64 arm64].freeze
 # 24.2 supports OpenSSL 3 and modern gcc/autoconf versions
 FIRST_SANE_VERSION = Gem::Version.new("24.2")
 
+def skip_release?(dist:, version:)
+  return true if version == "patch-base-26"
+  # Debian Bookworm doesn't have gcc 9 which is required for erlang <24.2
+  return true if dist == "debian/bookworm" && Gem::Version.new(version) < FIRST_SANE_VERSION
+
+  false
+end
+
 packagecloud = Packagecloud.new
 github = Github.new
 
@@ -17,8 +25,7 @@ github.releases do |r|
   next if r["tag_name"].include? "-rc"
   version = r["tag_name"].sub("OTP-", "")
   DISTS.each do |dist|
-    # Debian Bookworm doesn't have gcc 9 which is required for erlang <24.2
-    next if dist == "debian/bookworm" && Gem::Version.new(version) < FIRST_SANE_VERSION
+    next if skip_release?(dist:, version:)
     PLATFORMS.each do |platform|
       filename = "esl-erlang_#{version}-1_#{platform}.deb"
       next if packagecloud.exists? dist, filename


### PR DESCRIPTION
There's a weird release at: https://github.com/erlang/otp/releases/tag/patch-base-26 - it makes us barf when trying to parse as a `Gem::Version`, see https://github.com/cloudamqp/erlang-packages/actions/runs/10880399934/job/30187120021#step:4:10.

Refactor a bit to support all strangeness in one place.