### PR TITLE
Skip releases that do not start with "OTP-"

### DIFF
--- a/bin/missing-versions
+++ b/bin/missing-versions
@@ -15,6 +15,7 @@ github.releases do |r|
   next if r["prerelease"]
   next if r["draft"]
   next if r["tag_name"].include? "-rc"
+  next unless r["tag_name"].start_with?("OTP-")
   version = r["tag_name"].sub("OTP-", "")
   DISTS.each do |dist|
     # Debian Bookworm doesn't have gcc 9 which is required for erlang <24.2


### PR DESCRIPTION
From https://github.com/cloudamqp/erlang-packages/pull/12#issuecomment-2354750224

> Any tag that does not have a `OTP-` prefix you can ignore.

We had a problem with a release called "patch-base-26", see #12 for more information.
