### PR TITLE
Fix paging for Packagecloud

### DIFF
--- a/lib/packagecloud.rb
+++ b/lib/packagecloud.rb
@@ -45,7 +45,7 @@ class Packagecloud
 
   def packages
     packages = []
-    1.upto(10) do |page|
+    (1..).each do |page|
       path = "/api/v1/repos/cloudamqp/erlang/packages.json?per_page=250&page=#{page}"
       request = Net::HTTP::Get.new(path)
       request.basic_auth(@token, "")
@@ -68,5 +68,3 @@ class Packagecloud
     JSON.parse resp.body
   end
 end
-
-


### PR DESCRIPTION
Currently, we have 2647 packages in the repo. The old paging would only get the oldest 2500 (10 * 250), meaning we would always try to upload those extra 147 packages again. [Example](https://github.com/cloudamqp/erlang-packages/actions/runs/14261404102).

Let's go with endless range, we already break when we aren't getting any new results.