### PR TITLE
Build for Ubuntu 26.04 (resolute), drop 20.04 (focal)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Excluded erlang packages:
 
 ## Versions
 
-Every [version of Erlang that is released on GitHub](https://github.com/erlang/otp/releases) is built, currently for Ubuntu 22.04, 24.04 and 26.04.
+Every [version of Erlang ≥ 22 that is released on GitHub](https://github.com/erlang/otp/releases) is built, currently for Ubuntu 22.04, 24.04 and 26.04.
 
 ## Caveat
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Excluded erlang packages:
 
 ## Versions
 
-Every [version of Erlang that is released on GitHub](https://github.com/erlang/otp/releases) is built, currently for Ubuntu 20.04, 22.04 and 24.04.
+Every [version of Erlang that is released on GitHub](https://github.com/erlang/otp/releases) is built, currently for Ubuntu 22.04, 24.04 and 26.04.
 
 ## Caveat
 

--- a/bin/missing-versions
+++ b/bin/missing-versions
@@ -6,6 +6,7 @@ DISTS = %w[ubuntu/resolute ubuntu/noble ubuntu/jammy debian/bookworm debian/bull
 PLATFORMS = %w[amd64 arm64].freeze
 # 24.2 supports OpenSSL 3 and modern gcc/autoconf versions
 FIRST_SANE_VERSION = Gem::Version.new("24.2")
+MIN_VERSION = Gem::Version.new("22.0")
 
 packagecloud = Packagecloud.new
 github = Github.new
@@ -17,6 +18,7 @@ github.releases do |r|
   next if r["tag_name"].include? "-rc"
   next unless r["tag_name"].start_with?("OTP-")
   version = r["tag_name"].sub("OTP-", "")
+  next if Gem::Version.new(version) < MIN_VERSION
   DISTS.each do |dist|
     # Debian Bookworm doesn't have gcc 9 which is required for erlang <24.2
     next if dist == "debian/bookworm" && Gem::Version.new(version) < FIRST_SANE_VERSION

--- a/bin/missing-versions
+++ b/bin/missing-versions
@@ -2,7 +2,7 @@
 require_relative "../lib/github"
 require_relative "../lib/packagecloud"
 
-DISTS = %w[ubuntu/noble ubuntu/jammy ubuntu/focal debian/bookworm debian/bullseye].freeze
+DISTS = %w[ubuntu/resolute ubuntu/noble ubuntu/jammy debian/bookworm debian/bullseye].freeze
 PLATFORMS = %w[amd64 arm64].freeze
 # 24.2 supports OpenSSL 3 and modern gcc/autoconf versions
 FIRST_SANE_VERSION = Gem::Version.new("24.2")


### PR DESCRIPTION
## Summary
- Add `ubuntu/resolute` (26.04 LTS) to the build matrix
- Remove `ubuntu/focal` (20.04) — no longer building new packages for it
- Update README to reflect the new set (22.04, 24.04, 26.04)

Existing focal `.deb`s already on PackageCloud are untouched; this only stops future builds/uploads for focal.

## Test plan
- [ ] CI matrix picks up `ubuntu/resolute` and `bin/missing-versions` produces uploads for it
- [ ] No more focal entries appear in the matrix