### PR TITLE
Don't upload to PackageCloud on pull requests

### DIFF
--- a/.github/workflows/build-all-and-upload.yml
+++ b/.github/workflows/build-all-and-upload.yml
@@ -51,4 +51,5 @@ jobs:
       - name: Build Erlang version and upload to PackageCloud
         env:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+          UPLOAD: ${{ github.event_name != 'pull_request' }}
         run : bin/build-and-upload ${{ matrix.version }} ${{ matrix.image }} ${{ matrix.platform }}

--- a/bin/build-and-upload
+++ b/bin/build-and-upload
@@ -13,6 +13,9 @@ system("depot", "build",
        "--output", ".",
        ".", exception: true)
 
+# On pull requests we build to validate changes but don't publish
+exit if ENV["UPLOAD"] == "false"
+
 packagecloud = Packagecloud.new
 File.open("esl-erlang_#{version}-1_#{platform}.deb") do |file|
   packagecloud.upload(image.sub(":", "/"), file)


### PR DESCRIPTION
## Summary
- Gate the PackageCloud upload behind an `UPLOAD` env var in `bin/build-and-upload`.
- Set `UPLOAD: ${{ github.event_name != 'pull_request' }}` in the workflow.

## Why
The workflow triggers on `pull_request`, but `bin/build-and-upload` always called `packagecloud.upload(...)` with no guard. That meant opening a PR would build every missing Erlang version and **publish it to PackageCloud** — publishing from unmerged branches.

With this change, PRs still build every missing version (validating Dockerfile/matrix changes), but only `push` to main, `schedule`, and `workflow_dispatch` actually upload. Local runs without `UPLOAD` set keep uploading as before.

## Test plan
- [ ] On a PR, the build job runs but skips the upload step
- [ ] On main/schedule/dispatch, builds upload to PackageCloud as before